### PR TITLE
Ошибка при подсчёте количества недель

### DIFF
--- a/javascript/weeksInYear.js
+++ b/javascript/weeksInYear.js
@@ -1,7 +1,7 @@
 function getWeekNumber(d) {
     // Copy date so don't modify original
     d = new Date(+d);
-    d.setHours(0,0,0);
+    d.setHours(0,0,0,0);
     // Set to nearest Thursday: current date + 4 - current day number
     // Make Sunday's day number 7
     d.setDate(d.getDate() + 4 - (d.getDay()||7));


### PR DESCRIPTION
в строчке 4  - не хватало одного 0 - для сбрасывания микросикунд - без него не корректро считает кол-во недель.